### PR TITLE
FEATURE/#80 getUserPollMovies controller 추가

### DIFF
--- a/src/movie-list/dto/poll-movie-list-response.dto.ts
+++ b/src/movie-list/dto/poll-movie-list-response.dto.ts
@@ -3,32 +3,56 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString, IsArray, IsOptional, IsIn } from 'class-validator';
 
 export class PollMovieDto {
-  @ApiProperty({ description: '영화의 고유 식별자' })
+  @ApiProperty({
+    description: '영화의 고유 식별자',
+    example: 1,
+  })
   @Expose()
   @IsNumber()
   movieId: number;
 
-  @ApiProperty({ description: '영화 제목' })
+  @ApiProperty({
+    description: '영화 제목',
+    example: 'Inception',
+  })
   @Expose()
   @IsString()
   movieTitle: string;
 
-  @ApiProperty({ description: '영화 포스터의 URL 리스트' })
+  @ApiProperty({
+    description: '영화 포스터의 URL 리스트',
+    type: [String],
+    example: [
+      'https://example.com/poster1.jpg',
+      'https://example.com/poster2.jpg',
+    ],
+  })
   @Expose()
   @IsArray()
   posterUrl: string[];
 
-  @ApiProperty({ description: '주가 상승에 투표한 수' })
+  @ApiProperty({
+    description: '주가 상승에 투표한 수',
+    example: 120,
+  })
   @Expose()
   @IsNumber()
   up: number;
 
-  @ApiProperty({ description: '주가 하락에 투표한 수' })
+  @ApiProperty({
+    description: '주가 하락에 투표한 수',
+    example: 45,
+  })
   @Expose()
   @IsNumber()
   down: number;
 
-  @ApiProperty({ description: '내 투표 결과', required: false })
+  @ApiProperty({
+    description: '내 투표 결과',
+    enum: ['up', 'down', null],
+    required: false,
+    example: 'up',
+  })
   @Expose()
   @IsOptional()
   @IsIn(['up', 'down', null])
@@ -36,13 +60,19 @@ export class PollMovieDto {
   myPollResult?: 'up' | 'down' | null;
 }
 
-class moviePaginationDto {
-  @ApiProperty({ description: '현재 페이지 번호' })
+export class MoviePaginationDto {
+  @ApiProperty({
+    description: '현재 페이지 번호',
+    example: 1,
+  })
   @Expose()
   @IsNumber()
   currentPage: number;
 
-  @ApiProperty({ description: '전체 페이지 수' })
+  @ApiProperty({
+    description: '전체 페이지 수',
+    example: 10,
+  })
   @Expose()
   @IsNumber()
   totalPages: number;
@@ -57,13 +87,19 @@ export class PollMovieListResponseDto {
   @IsArray()
   movieList: PollMovieDto[];
 
-  @ApiProperty({ description: '목록에 있는 영화 수' })
+  @ApiProperty({
+    description: '목록에 있는 영화 수',
+    example: 25,
+  })
   @Expose()
   @IsNumber()
   movieListCount: number;
 
-  @ApiProperty({ description: '현재 페이지 번호' })
+  @ApiProperty({
+    description: '페이지네이션 정보',
+    type: MoviePaginationDto,
+  })
   @Expose()
   @IsNumber()
-  pagination: moviePaginationDto;
+  pagination: MoviePaginationDto;
 }

--- a/src/movie-list/movie-list.controller.ts
+++ b/src/movie-list/movie-list.controller.ts
@@ -59,7 +59,6 @@ export class MovieListController {
   @ApiOkResponse({
     description: '투표 중인 영화 목록을 제공한다.',
     type: PollMovieListResponseDto,
-    isArray: true,
   })
   @ApiBadRequestResponse({
     description:

--- a/src/users/dto/user-poll-movie-list-response.dto.ts
+++ b/src/users/dto/user-poll-movie-list-response.dto.ts
@@ -1,0 +1,150 @@
+import {
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsArray,
+  IsEnum,
+  IsDateString,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum PollResult {
+  UP = 'up',
+  DOWN = 'down',
+  NONE = null,
+}
+
+export class UserPollMovieDto {
+  @ApiProperty({
+    description: '영화의 고유 식별자',
+    example: 1,
+  })
+  @IsNumber()
+  movieId: number;
+
+  @ApiProperty({
+    description: '영화 제목',
+    example: 'Inception',
+  })
+  @IsString()
+  movieTitle: string;
+
+  @ApiProperty({
+    description: '영화 포스터의 URL 리스트',
+    type: [String],
+    example: [
+      'https://example.com/poster1.jpg',
+      'https://example.com/poster2.jpg',
+    ],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  posterUrl: string[];
+
+  @ApiProperty({
+    description: '주가 상승에 투표한 수',
+    example: 120,
+  })
+  @IsNumber()
+  up: number;
+
+  @ApiProperty({
+    description: '주가 하락에 투표한 수',
+    example: 45,
+  })
+  @IsNumber()
+  down: number;
+
+  @ApiProperty({
+    description: '내 투표 결과',
+    enum: PollResult,
+    example: PollResult.UP || PollResult.NONE,
+  })
+  @IsEnum(PollResult)
+  pollResult: PollResult;
+
+  @ApiProperty({
+    description: '영화가 제작된 국가 코드',
+    example: 'US',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  countryCode?: string;
+
+  @ApiProperty({
+    description: '투표 전 영화 가격',
+    example: 15.99,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  beforePrice?: number;
+
+  @ApiProperty({
+    description: '투표 전 영화 가격의 날짜',
+    example: '2024-08-15',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString()
+  beforePriceDate?: string;
+
+  @ApiProperty({
+    description: '투표 후 영화 가격',
+    example: 17.99,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  afterPrice?: number;
+
+  @ApiProperty({
+    description: '투표 후 영화 가격의 날짜',
+    example: '2024-08-16',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString()
+  afterPriceDate?: string;
+}
+
+export class UserPollPaginationDto {
+  @ApiProperty({
+    description: '현재 페이지 번호',
+    example: 1,
+  })
+  @IsNumber()
+  currentPage: number;
+
+  @ApiProperty({
+    description: '전체 페이지 수',
+    example: 10,
+  })
+  @IsNumber()
+  totalPages: number;
+}
+
+export class UserPollMovieListResponseDto {
+  @ApiProperty({
+    type: [UserPollMovieDto],
+    description: '투표 중인 영화 목록',
+  })
+  @Type(() => UserPollMovieDto)
+  movieList: UserPollMovieDto[];
+
+  @ApiProperty({
+    description: '목록에 있는 영화 수',
+    example: 25,
+  })
+  @IsNumber()
+  movieListCount: number;
+
+  @ApiProperty({
+    description: '페이지네이션 정보',
+    type: UserPollPaginationDto,
+  })
+  @Type(() => UserPollPaginationDto)
+  pagination: UserPollPaginationDto;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,15 +1,32 @@
-import { Controller, Get, UseGuards, Request } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  UseGuards,
+  Request,
+  Query,
+  DefaultValuePipe,
+  ParseIntPipe,
+  ParseBoolPipe,
+} from '@nestjs/common';
 import { UsersService } from './users.service';
 import { AccessTokenGuard } from 'src/auth/accessToken.guard';
 import {
+  ApiBadRequestResponse,
   ApiHeader,
+  ApiInternalServerErrorResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { UserInfo } from './dto/userInfo.dto';
+import { UserPollMovieListResponseDto } from './dto/user-poll-movie-list-response.dto';
+import {
+  SWAGGER_BAD_REQUERST_CONTENT,
+  SWAGGER_INTERNAL_SERVER_ERROR_CONTENT,
+} from 'src/constants';
 
 @ApiTags('user 관련')
 @Controller('api/v1/users')
@@ -47,5 +64,59 @@ export class UsersController {
       point: userInfo.point,
       rank: userInfo.rank,
     };
+  }
+
+  @Get('/poll')
+  @ApiOperation({
+    summary: '유저가 투표한 영화 목록 API',
+    description: '유저가 투표한 투표 중 혹은 투표 마감된 영화 목록을 제공한다.',
+  })
+  @ApiQuery({
+    name: 'poll',
+    required: true,
+    description: '투표 결과 필터링 여부 (true 또는 false)',
+  })
+  @ApiQuery({
+    name: 'year',
+    required: false,
+    description: '영화 개봉 연도',
+    example: new Date().getFullYear(),
+  })
+  @ApiOkResponse({
+    description: '투표 중인 영화 목록을 제공한다.',
+    type: UserPollMovieListResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description:
+      '쿼리 파라미터 형식을 맞추어주세요.\
+      \n\n e.g) "/api/v1/users/poll?poll=true&year=2024"',
+    content: SWAGGER_BAD_REQUERST_CONTENT,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버 내부 오류로 인해 영화 목록을 가져올 수 없습니다.',
+    content: SWAGGER_INTERNAL_SERVER_ERROR_CONTENT,
+  })
+  async getUserPollMovies(
+    @Query('poll', new DefaultValuePipe(true), ParseBoolPipe) poll: boolean,
+    @Query('year', new DefaultValuePipe(new Date().getFullYear()), ParseIntPipe)
+    year: number,
+  ): Promise<UserPollMovieListResponseDto> {
+    try {
+      // TODO: request header에서 token 뽑아내기
+      const userId: number | null = null;
+
+      if (poll === true) {
+        return this.userService.getUserPollingMovies(true, year, userId);
+      } else if (poll === false) {
+        return this.userService.getUserPolledMovies(false, year, userId);
+      } else {
+        // TODO: 에러 헨들링
+        throw new Error('Invalid poll query parameter');
+      }
+    } catch (err) {
+      // TODO: 에러 헨들링
+      console.error('Error in /api/v1/movie/list?poll=true  : ', poll);
+      throw err;
+    }
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -6,6 +6,11 @@ import {
 import { UsersModel } from './entities/users.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MoreThan, Repository } from 'typeorm';
+import { PollMovieListResponseDto } from 'src/movie-list/dto/poll-movie-list-response.dto';
+import {
+  PollResult,
+  UserPollMovieListResponseDto,
+} from './dto/user-poll-movie-list-response.dto';
 
 @Injectable()
 export class UsersService {
@@ -124,5 +129,127 @@ export class UsersService {
       console.log('Error select user table in getUserInfo service');
       throw new BadRequestException();
     }
+  }
+
+  // (true, year, userId)
+  async getUserPollingMovies(
+    poll: boolean,
+    year: number,
+    userId: number,
+  ): Promise<UserPollMovieListResponseDto> {
+    console.log(poll);
+    console.log(year);
+    console.log(userId);
+
+    return {
+      movieList: [
+        {
+          movieId: 1,
+          movieTitle: 'Inception',
+          posterUrl: [
+            'https://example.com/poster1.jpg',
+            'https://example.com/poster2.jpg',
+          ],
+          up: 12,
+          down: 45,
+          pollResult: PollResult.UP,
+        },
+        {
+          movieId: 2,
+          movieTitle: 'The Matrix',
+          posterUrl: [
+            'https://example.com/matrix1.jpg',
+            'https://example.com/matrix2.jpg',
+          ],
+          up: 9,
+          down: 12,
+          pollResult: PollResult.DOWN,
+        },
+        {
+          movieId: 3,
+          movieTitle: 'Interstellar',
+          posterUrl: [
+            'https://example.com/interstellar1.jpg',
+            'https://example.com/interstellar2.jpg',
+          ],
+          up: 23,
+          down: 2,
+          pollResult: PollResult.NONE,
+        },
+      ],
+      movieListCount: 3,
+      pagination: {
+        currentPage: 1,
+        totalPages: 1,
+      },
+    };
+  }
+
+  async getUserPolledMovies(
+    poll: boolean,
+    year: number,
+    userId: number,
+  ): Promise<UserPollMovieListResponseDto> {
+    console.log(poll);
+    console.log(year);
+    console.log(userId);
+
+    return {
+      movieList: [
+        {
+          movieId: 1,
+          movieTitle: 'Inception',
+          posterUrl: [
+            'https://example.com/poster1.jpg',
+            'https://example.com/poster2.jpg',
+          ],
+          up: 120,
+          down: 45,
+          pollResult: PollResult.UP,
+          countryCode: 'US',
+          beforePrice: 15.99,
+          beforePriceDate: '2024-08-14',
+          afterPrice: 17.99,
+          afterPriceDate: '2024-08-15',
+        },
+        {
+          movieId: 2,
+          movieTitle: 'The Matrix',
+          posterUrl: [
+            'https://example.com/matrix1.jpg',
+            'https://example.com/matrix2.jpg',
+          ],
+          up: 90,
+          down: 30,
+          pollResult: PollResult.DOWN,
+          countryCode: 'US',
+          beforePrice: 13.5,
+          beforePriceDate: '2024-08-14',
+          afterPrice: 12.99,
+          afterPriceDate: '2024-08-15',
+        },
+        {
+          movieId: 3,
+          movieTitle: 'Interstellar',
+          posterUrl: [
+            'https://example.com/interstellar1.jpg',
+            'https://example.com/interstellar2.jpg',
+          ],
+          up: 200,
+          down: 60,
+          pollResult: PollResult.NONE,
+          countryCode: 'US',
+          beforePrice: 20.0,
+          beforePriceDate: '2024-08-14',
+          afterPrice: 21.0,
+          afterPriceDate: '2024-08-15',
+        },
+      ],
+      movieListCount: 3,
+      pagination: {
+        currentPage: 1,
+        totalPages: 1,
+      },
+    };
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -6,7 +6,6 @@ import {
 import { UsersModel } from './entities/users.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MoreThan, Repository } from 'typeorm';
-import { PollMovieListResponseDto } from 'src/movie-list/dto/poll-movie-list-response.dto';
 import {
   PollResult,
   UserPollMovieListResponseDto,
@@ -131,7 +130,6 @@ export class UsersService {
     }
   }
 
-  // (true, year, userId)
   async getUserPollingMovies(
     poll: boolean,
     year: number,


### PR DESCRIPTION

## #️⃣연관된 이슈

> #80 

## 📝작업 내용

- 사용자가 투표한 영화 목록을 보여주는 api controller 추가
  - 투표 중인 영화
  - 투표 마감된 영화

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/338f2b24-e796-4917-a831-5943aee02a03)

![image](https://github.com/user-attachments/assets/87d97e14-9242-4945-876a-4decfe345c59)

![image](https://github.com/user-attachments/assets/78682de9-0e15-4415-8fa8-22dc69c5ded8)

![image](https://github.com/user-attachments/assets/fbd5b352-3be9-41f3-bad8-77f410ab548d)

![image](https://github.com/user-attachments/assets/e5efcfef-2b29-4c31-907d-c27409869873)



## 💬리뷰 요구사항(선택)

- 마이페이지에서 보게될 투표한 영화 목록의 경우
정렬 조건이 api 문서에는 정의된 것이 없는데
전에 저희끼리 논의 했었을 때 개봉일 내림차순, 투표 많은 순 등 
이야기 나왔었습니다.
정렬 조건 추가할까요?