### PR TITLE
[FEATURE] 영화 4주 전/후 주가 가격 정보

### DIFF
--- a/src/stocks/dto/company.dto.ts
+++ b/src/stocks/dto/company.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CompanyDto {
+  companyCd: string;
+
+  companyName: string;
+
+  tickerName: string;
+
+  country: string;
+}

--- a/src/stocks/dto/company.dto.ts
+++ b/src/stocks/dto/company.dto.ts
@@ -1,12 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsNumber } from 'class-validator';
-
 export class CompanyDto {
   companyCd: string;
-
   companyName: string;
-
   tickerName: string;
-
   country: string;
 }

--- a/src/stocks/dto/stock.dto.ts
+++ b/src/stocks/dto/stock.dto.ts
@@ -1,0 +1,9 @@
+export class StockDto {
+  stockId: number;
+
+  tickerName: string;
+
+  closePrice: string;
+
+  stockDate: Date;
+}

--- a/src/stocks/dto/stock.dto.ts
+++ b/src/stocks/dto/stock.dto.ts
@@ -1,9 +1,6 @@
 export class StockDto {
   stockId: number;
-
   tickerName: string;
-
   closePrice: string;
-
   stockDate: Date;
 }

--- a/src/stocks/dto/stockInfoByMovieId.dto.ts
+++ b/src/stocks/dto/stockInfoByMovieId.dto.ts
@@ -36,4 +36,10 @@ export class StockInfoResponseByMovieId {
     type: String,
   })
   companyName: string;
+
+  @ApiProperty({
+    description: '회사 상장 국가 코드',
+    type: String,
+  })
+  countryCode: string;
 }

--- a/src/stocks/dto/stockInfoByMovieId.dto.ts
+++ b/src/stocks/dto/stockInfoByMovieId.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StockInfoResponseByMovieId {
+  @ApiProperty({
+    description: '개봉 4주 전 날짜(YYYY-MM-DD)',
+    type: Date,
+  })
+  beforePriceDate: Date;
+
+  @ApiProperty({
+    description: '개봉 4주 전 주가',
+    type: Number,
+  })
+  beforePrice: number;
+
+  @ApiProperty({
+    description: '개봉 4주 후 날짜(YYYY-MM-DD)',
+    type: Date,
+  })
+  afterPriceDate: Date;
+
+  @ApiProperty({
+    description: '개봉 4주 후 주가',
+    type: Number,
+  })
+  afterPrice: number;
+
+  @ApiProperty({
+    description: '관련 업계 평균 주가 변화율',
+    type: Number,
+  })
+  stockIndustryAverageVariation: number;
+
+  @ApiProperty({
+    description: '회사 이름',
+    type: String,
+  })
+  companyName: string;
+}

--- a/src/stocks/stocks.controller.ts
+++ b/src/stocks/stocks.controller.ts
@@ -7,11 +7,36 @@ export class StocksController {
 
   @Get(':movieId')
   async getStockPriceByMovieId(@Param('movieId') movieId: string) {
-    // 없는 movieId -> 404
-    // 아니면 주가 정보 반환
-    console.log(movieId);
+    const movie = await this.stocksService.findMovieByMovieId(+movieId);
+    const company = await this.stocksService.findCompanyByCompanyCd(
+      movie.companyId,
+    );
 
-    const company = await this.stocksService.findCompanyByMovieId(+movieId);
-    return company;
+    const fourWeeksBeforeStock = await this.stocksService.getStockInfo(
+      movie.movieOpenDate,
+      company.tickerName,
+      true,
+    );
+
+    const fourWeeksAfterStock = await this.stocksService.getStockInfo(
+      movie.movieOpenDate,
+      company.tickerName,
+      false,
+    );
+
+    const averageStockVariation =
+      await this.stocksService.getAverageStockVariation(
+        fourWeeksBeforeStock.stockDate,
+        fourWeeksAfterStock.stockDate,
+        company.country,
+      );
+
+    return {
+      beforePriceDate: fourWeeksBeforeStock.stockDate,
+      beforePrice: parseFloat(fourWeeksBeforeStock.closePrice),
+      afterPriceDate: fourWeeksAfterStock.stockDate,
+      afterPrice: parseFloat(fourWeeksAfterStock.closePrice),
+      stockIndustryAverageVariation: parseFloat(averageStockVariation),
+    };
   }
 }

--- a/src/stocks/stocks.controller.ts
+++ b/src/stocks/stocks.controller.ts
@@ -1,12 +1,38 @@
 import { Controller, Get, Param } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { StockInfoResponseByMovieId } from './dto/stockInfoByMovieId.dto';
 import { StocksService } from './stocks.service';
 
+@ApiTags('영화 관련 회사 주가 정보 조회 api')
 @Controller('/api/v1/stocks')
 export class StocksController {
   constructor(private readonly stocksService: StocksService) {}
 
   @Get(':movieId')
-  async getStockPriceByMovieId(@Param('movieId') movieId: string) {
+  @ApiOperation({
+    summary: '영화 관련주 주가 정보 조회',
+    description:
+      '영화 개봉일 전후 4주간의 주가정보 및 같은 날짜의 업계 평균 주가 변화율을 얻습니다.',
+  })
+  @ApiOkResponse({
+    description: '조회 성공',
+    type: StockInfoResponseByMovieId,
+  })
+  @ApiNotFoundResponse({
+    description: 'movieId와 일치하는 영화가 없습니다.',
+  })
+  @ApiBadRequestResponse({
+    description: '알 수 없는 이유로 데이터를 가져오는데 실패했습니다.',
+  })
+  async getStockPriceByMovieId(
+    @Param('movieId') movieId: string,
+  ): Promise<StockInfoResponseByMovieId | null> {
     const movie = await this.stocksService.findMovieByMovieId(+movieId);
     const company = await this.stocksService.findCompanyByCompanyCd(
       movie.companyId,

--- a/src/stocks/stocks.controller.ts
+++ b/src/stocks/stocks.controller.ts
@@ -14,7 +14,7 @@ import { StocksService } from './stocks.service';
 export class StocksController {
   constructor(private readonly stocksService: StocksService) {}
 
-  @Get(':movieId')
+  @Get('/movie/:movieId')
   @ApiOperation({
     summary: '영화 관련주 주가 정보 조회',
     description:

--- a/src/stocks/stocks.controller.ts
+++ b/src/stocks/stocks.controller.ts
@@ -6,7 +6,10 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
+import { Movie } from 'src/poll/entities/movie.entity';
 import { StockInfoResponseByMovieId } from './dto/stockInfoByMovieId.dto';
+import { Company } from './entities/company.entity';
+import { Stock } from './entities/stock.entity';
 import { StocksService } from './stocks.service';
 
 @ApiTags('영화 관련 회사 주가 정보 조회 api')
@@ -33,18 +36,18 @@ export class StocksController {
   async getStockPriceByMovieId(
     @Param('movieId') movieId: string,
   ): Promise<StockInfoResponseByMovieId | null> {
-    const movie = await this.stocksService.findMovieByMovieId(+movieId);
-    const company = await this.stocksService.findCompanyByCompanyCd(
+    const movie: Movie = await this.stocksService.findMovieByMovieId(+movieId);
+    const company: Company = await this.stocksService.findCompanyByCompanyCd(
       movie.companyId,
     );
 
-    const fourWeeksBeforeStock = await this.stocksService.getStockInfo(
+    const fourWeeksBeforeStock: Stock = await this.stocksService.getStockInfo(
       movie.movieOpenDate,
       company.tickerName,
       true,
     );
 
-    const fourWeeksAfterStock = await this.stocksService.getStockInfo(
+    const fourWeeksAfterStock: Stock = await this.stocksService.getStockInfo(
       movie.movieOpenDate,
       company.tickerName,
       false,
@@ -64,6 +67,7 @@ export class StocksController {
       afterPrice: parseFloat(fourWeeksAfterStock.closePrice),
       stockIndustryAverageVariation: parseFloat(averageStockVariation),
       companyName: company.companyName,
+      countryCode: company.country,
     };
   }
 }

--- a/src/stocks/stocks.controller.ts
+++ b/src/stocks/stocks.controller.ts
@@ -36,38 +36,6 @@ export class StocksController {
   async getStockPriceByMovieId(
     @Param('movieId') movieId: string,
   ): Promise<StockInfoResponseByMovieId | null> {
-    const movie: Movie = await this.stocksService.findMovieByMovieId(+movieId);
-    const company: Company = await this.stocksService.findCompanyByCompanyCd(
-      movie.companyId,
-    );
-
-    const fourWeeksBeforeStock: Stock = await this.stocksService.getStockInfo(
-      movie.movieOpenDate,
-      company.tickerName,
-      true,
-    );
-
-    const fourWeeksAfterStock: Stock = await this.stocksService.getStockInfo(
-      movie.movieOpenDate,
-      company.tickerName,
-      false,
-    );
-
-    const averageStockVariation =
-      await this.stocksService.getAverageStockVariation(
-        fourWeeksBeforeStock.stockDate,
-        fourWeeksAfterStock.stockDate,
-        company.country,
-      );
-
-    return {
-      beforePriceDate: fourWeeksBeforeStock.stockDate,
-      beforePrice: parseFloat(fourWeeksBeforeStock.closePrice),
-      afterPriceDate: fourWeeksAfterStock.stockDate,
-      afterPrice: parseFloat(fourWeeksAfterStock.closePrice),
-      stockIndustryAverageVariation: parseFloat(averageStockVariation),
-      companyName: company.companyName,
-      countryCode: company.country,
-    };
+    return this.stocksService.getStockInfoByMovieId(+movieId);
   }
 }

--- a/src/stocks/stocks.controller.ts
+++ b/src/stocks/stocks.controller.ts
@@ -6,10 +6,7 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { Movie } from 'src/poll/entities/movie.entity';
 import { StockInfoResponseByMovieId } from './dto/stockInfoByMovieId.dto';
-import { Company } from './entities/company.entity';
-import { Stock } from './entities/stock.entity';
 import { StocksService } from './stocks.service';
 
 @ApiTags('영화 관련 회사 주가 정보 조회 api')

--- a/src/stocks/stocks.controller.ts
+++ b/src/stocks/stocks.controller.ts
@@ -37,6 +37,7 @@ export class StocksController {
       afterPriceDate: fourWeeksAfterStock.stockDate,
       afterPrice: parseFloat(fourWeeksAfterStock.closePrice),
       stockIndustryAverageVariation: parseFloat(averageStockVariation),
+      companyName: company.companyName,
     };
   }
 }

--- a/src/stocks/stocks.service.ts
+++ b/src/stocks/stocks.service.ts
@@ -5,10 +5,12 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Movie } from 'src/poll/entities/movie.entity';
-import { get4WeeksPrevPriceByOpenDate } from 'src/util/date';
-import { Repository } from 'typeorm';
+import { shiftDateByWeeks, getYesterdayDate } from 'src/util/date';
+import { Repository, Between } from 'typeorm';
 import { Company } from './entities/company.entity';
 import { Stock } from './entities/stock.entity';
+import { StockDto } from './dto/stock.dto';
+import { CompanyDto } from './dto/company.dto';
 
 @Injectable()
 export class StocksService {
@@ -23,9 +25,7 @@ export class StocksService {
     private readonly companyRepository: Repository<Company>,
   ) {}
 
-  /*
-  depreciated
-  async findMovieByMovieId(movieId: number) {
+  async findMovieByMovieId(movieId: number): Promise<Movie | null> {
     try {
       const movie = await this.movieRepository.findOne({
         where: { movieId: movieId },
@@ -38,42 +38,100 @@ export class StocksService {
     }
   }
 
-  async findCompanyByCompanyCd(companyCd: string) {
-    const company = await this.companyRepository.findOne({
-      where: { companyCd: companyCd },
-    });
-
-    return company;
-  }
-*/
-  async findCompanyByMovieId(movieId: number) {
+  async findCompanyByCompanyCd(companyCd: string): Promise<CompanyDto | null> {
     try {
-      // 영화 검색
-      const movie = await this.movieRepository.findOne({
-        where: { movieId: movieId },
-      });
-      if (!movie) throw new NotFoundException('존재하지 않는 영화 id입니다.');
-      console.log(movie.movieOpenDate);
-      // 회사 검색
       const company = await this.companyRepository.findOne({
-        where: { companyCd: movie.companyId },
+        where: { companyCd: companyCd },
       });
-      // 가격을 찾는데
-      // 없으면 그 전날이나
-      // 그 전전날
-      const candidateDates = get4WeeksPrevPriceByOpenDate(movie.movieOpenDate);
-      console.log(candidateDates);
-      const price = await this.stockRepository.find({
-        where: {
-          tickerName: company.tickerName,
-          stockDate: candidateDates[0],
-        },
-      });
-      console.log(price);
+
       return company;
     } catch (error) {
-      console.log('error : ', error);
-      console.log('Error while search company by movieId');
+      console.log('Error while search movie by movieId');
+      throw new BadRequestException();
+    }
+  }
+
+  async getStockInfo(
+    openDate: Date,
+    tickerName: string,
+    isPast: boolean,
+  ): Promise<StockDto | null> {
+    try {
+      let shiftedDate = isPast
+        ? shiftDateByWeeks(openDate, true)
+        : shiftDateByWeeks(openDate, false);
+      let stock: StockDto;
+      // 4주 shift된 날짜가 휴장일일 가능성 체크 + 개봉 4주가 지나지 않았을 가능성 체크
+      while (1) {
+        stock = await this.stockRepository.findOne({
+          where: {
+            tickerName: tickerName,
+            stockDate: shiftedDate,
+          },
+        });
+        if (!stock) shiftedDate = getYesterdayDate(shiftedDate);
+        else break;
+      }
+
+      return stock;
+    } catch (error) {
+      console.log('Error in getStockInfoByMovieId', error);
+      throw new BadRequestException();
+    }
+  }
+
+  async getAverageStockVariation(
+    fromDate: Date,
+    toDate: Date,
+    countryCode: string,
+  ) {
+    try {
+      // countryCode가 일치하는 회사를 찾습니다.
+      const companies = await this.companyRepository.find({
+        where: { country: countryCode },
+      });
+
+      // 각 회사에 대해 주어진 기간에 대해 최대 주가, 최소 주가를 찾습니다.
+      let priceBoundary = await Promise.all(
+        companies.map(async (company) => {
+          const prices = await this.stockRepository.find({
+            where: {
+              tickerName: company.tickerName,
+              stockDate: Between(fromDate, toDate),
+            },
+          });
+
+          let minPrice = Infinity;
+          let maxPrice = -Infinity;
+
+          prices.forEach((price) => {
+            if (+price.closePrice < minPrice) {
+              minPrice = +price.closePrice;
+            }
+            if (+price.closePrice > maxPrice) {
+              maxPrice = +price.closePrice;
+            }
+          });
+
+          return { minPrice, maxPrice };
+        }),
+      );
+
+      // 주가 변동률을 계산하고 평균을 구합니다.
+      let totalVariation = 0;
+      priceBoundary.forEach((boundary) => {
+        const { minPrice, maxPrice } = boundary;
+        if (minPrice !== Infinity && maxPrice !== -Infinity) {
+          const variation = ((maxPrice - minPrice) / minPrice) * 100;
+          totalVariation += variation;
+        }
+      });
+
+      const averageVariation = totalVariation / priceBoundary.length;
+
+      return averageVariation.toFixed(2);
+    } catch (error) {
+      console.log('Error in getAverageStockVariation', error);
       throw new BadRequestException();
     }
   }

--- a/src/stocks/stocks.service.ts
+++ b/src/stocks/stocks.service.ts
@@ -10,7 +10,6 @@ import { Repository, In } from 'typeorm';
 import { Company } from './entities/company.entity';
 import { Stock } from './entities/stock.entity';
 import { StockDto } from './dto/stock.dto';
-import { CompanyDto } from './dto/company.dto';
 import { StockInfoResponseByMovieId } from './dto/stockInfoByMovieId.dto';
 
 @Injectable()

--- a/src/stocks/stocks.service.ts
+++ b/src/stocks/stocks.service.ts
@@ -91,7 +91,7 @@ export class StocksService {
         where: { country: countryCode },
       });
 
-      // 각 회사에 대해 주어진 기간에 대해 최대 주가, 최소 주가를 찾습니다.
+      // 모든 회사에 대해 주어진 날짜의 주가를 얻음
       let priceBoundary = await Promise.all(
         companies.map(async (company) => {
           const prices = await this.stockRepository.find({

--- a/src/stocks/stocks.service.ts
+++ b/src/stocks/stocks.service.ts
@@ -11,6 +11,7 @@ import { Company } from './entities/company.entity';
 import { Stock } from './entities/stock.entity';
 import { StockDto } from './dto/stock.dto';
 import { CompanyDto } from './dto/company.dto';
+import { StockInfoResponseByMovieId } from './dto/stockInfoByMovieId.dto';
 
 @Injectable()
 export class StocksService {
@@ -25,29 +26,52 @@ export class StocksService {
     private readonly companyRepository: Repository<Company>,
   ) {}
 
-  async findMovieByMovieId(movieId: number): Promise<Movie | null> {
+  async getStockInfoByMovieId(
+    movieId: number,
+  ): Promise<StockInfoResponseByMovieId | null> {
     try {
-      const movie = await this.movieRepository.findOne({
+      const movie: Movie = await this.movieRepository.findOne({
         where: { movieId: movieId },
       });
       if (!movie) throw new NotFoundException('존재하지 않는 영화 id입니다.');
-      return movie;
-    } catch (error) {
-      console.log('Error while search movie by movieId');
-      throw new BadRequestException();
-    }
-  }
 
-  async findCompanyByCompanyCd(companyCd: string): Promise<CompanyDto | null> {
-    try {
-      const company = await this.companyRepository.findOne({
-        where: { companyCd: companyCd },
+      const company: Company = await this.companyRepository.findOne({
+        where: { companyCd: movie.companyId },
       });
 
-      return company;
+      const fourWeeksBeforeStock: Stock = await this.getStockInfo(
+        movie.movieOpenDate,
+        company.tickerName,
+        true,
+      );
+
+      const fourWeeksAfterStock: Stock = await this.getStockInfo(
+        movie.movieOpenDate,
+        company.tickerName,
+        false,
+      );
+
+      const averageStockVariation = await this.getAverageStockVariation(
+        fourWeeksBeforeStock.stockDate,
+        fourWeeksAfterStock.stockDate,
+        company.country,
+      );
+
+      return {
+        beforePriceDate: fourWeeksBeforeStock.stockDate,
+        beforePrice: parseFloat(fourWeeksBeforeStock.closePrice),
+        afterPriceDate: fourWeeksAfterStock.stockDate,
+        afterPrice: parseFloat(fourWeeksAfterStock.closePrice),
+        stockIndustryAverageVariation: parseFloat(averageStockVariation),
+        companyName: company.companyName,
+        countryCode: company.country,
+      };
     } catch (error) {
-      console.log('Error while search movie by movieId');
-      throw new BadRequestException();
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      console.log('error in getStockInfoByMovieId', error);
+      throw new BadRequestException('알 수 없는 이유로 요청에 실패하였습니다.');
     }
   }
 
@@ -76,7 +100,7 @@ export class StocksService {
       return stock;
     } catch (error) {
       console.log('Error in getStockInfoByMovieId', error);
-      throw new BadRequestException();
+      throw new BadRequestException('알 수 없는 이유로 요청에 실패하였습니다.');
     }
   }
 
@@ -121,7 +145,7 @@ export class StocksService {
       return averageVariation.toFixed(2);
     } catch (error) {
       console.log('Error in getAverageStockVariation', error);
-      throw new BadRequestException();
+      throw new BadRequestException('알 수 없는 이유로 요청에 실패하였습니다.');
     }
   }
 }

--- a/src/util/date.ts
+++ b/src/util/date.ts
@@ -1,12 +1,12 @@
 import * as dayjs from 'dayjs';
 
-export const get4WeeksPrevPriceByOpenDate = (openDate: Date) => {
-  const fourWeeksAgo = dayjs(openDate).subtract(4, 'week');
+// isPast:true -> 4주 전, false -> 4주 후
+export const shiftDateByWeeks = (openDate: Date, isPast: boolean) => {
+  return isPast
+    ? new Date(dayjs(openDate).subtract(4, 'week').format('YYYY-MM-DD'))
+    : new Date(dayjs(openDate).add(4, 'week').format('YYYY-MM-DD'));
+};
 
-  const dates = [];
-  for (let i = 0; i < 7; i++) {
-    dates.push(fourWeeksAgo.add(i, 'day').format('YYYY-MM-DD'));
-  }
-
-  return dates;
+export const getYesterdayDate = (date: Date) => {
+  return new Date(dayjs(date).subtract(1, 'day').format('YYYY-MM-DD'));
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> https://github.com/prgrms-fdc-2nd-final-mosdaq/mosdaq-back/issues/71

## 📝작업 내용

> 

- [x] 영화 개봉 4주 전/후 주가 가격 정보
- [x] 4주 전/후가 휴장일일 가능성 체크 -> 휴장일이라면 그 전날의 주가
- [x] 날짜 계산을 위한 utils/date.ts 작성
- [x] 관련 회사 주가 평균 변화율 반환
  (국가 코드로 대상 회사 리스트 추림 -> 개봉일 4주 전후의 추가 변화율의 평균 계산 -> DB 회사 개수가 적어서 편차가 너무 크다는 문제가 있음)



## 스크린샷 (선택)
<img width="376" alt="image" src="https://github.com/user-attachments/assets/a2cd7be9-3cce-4932-b95d-24bc3dbe6986">
<img width="359" alt="image" src="https://github.com/user-attachments/assets/c80e9f5b-18c9-4539-9b8b-5e218eab17f1">



## 💬리뷰 요구사항(선택)

> + api 엔드 포인트를 변경하면 어떨까 합니다. /api/v1/stock/movie/movieId
기존에 poll/:movie-id/stock-variation 는 응답 데이터에 맞지 않는 느낌이 있습니다.

>  + 서비스 내부에 getStockinfo 안에 while문 좀 위험해보이나요?
