### PR TITLE
REFACTOR/#101 메인페이지 배너 api 수정

### DIFF
--- a/src/main/dto/main-movie-response.dto.ts
+++ b/src/main/dto/main-movie-response.dto.ts
@@ -1,7 +1,7 @@
 // 📄 src/movies/dto/popular-movies-polled-response.dto.ts
 import { Expose } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsString, IsArray, IsISO8601 } from 'class-validator';
+import { IsNumber, IsString, IsArray } from 'class-validator';
 
 export class StockPriceDto {
   @ApiProperty({ description: '주식 가격' })
@@ -15,9 +15,7 @@ export class StockPriceDto {
   date: string;
 }
 
-// TO KNOW: Expose, Exclude 특징과 차이점 언제 쓰는가
 export class MainMovieDto {
-  // export class PopularMoviePolledMovieDto {
   @ApiProperty({ description: '영화의 고유 식별자' })
   @Expose()
   @IsNumber()
@@ -43,34 +41,9 @@ export class MainMovieDto {
   @IsString()
   companyName: string;
 
-  @ApiProperty({ description: '개봉 4주 전 주식 가격' })
-  @Expose()
-  @IsNumber()
-  beforePrice: number;
-
-  @ApiProperty({ description: '개봉 4주 후 주식 가격' })
-  @Expose()
-  @IsNumber()
-  afterPrice: number;
-
   @ApiProperty({
-    description: '개봉 4주 전 날짜',
-    example: '2023-01-01',
-  })
-  @Expose()
-  @IsISO8601()
-  beforeDate: string;
-
-  @ApiProperty({
-    description: '개봉 4주 후 날짜',
-    example: '2023-01-29',
-  })
-  @Expose()
-  @IsISO8601()
-  afterDate: string;
-
-  @ApiProperty({
-    description: '개봉 4, 8주 전, 개봉일, 개봉 4, 8주 후 주식 가격',
+    description: '개봉일 기준 4주 전 후, 총 8주 간의 주식 가격',
+    type: StockPriceDto,
   })
   @Expose()
   @IsArray()

--- a/src/main/entities/main-movie-view.entity.ts
+++ b/src/main/entities/main-movie-view.entity.ts
@@ -1,6 +1,7 @@
 import { ViewEntity, ViewColumn } from 'typeorm';
 
-@ViewEntity({ name: 'main_movie_view' })
+// TODO: main_movie_view로 변경
+@ViewEntity({ name: 'main_movie_view_to_be' })
 export class MainMovieView {
   @ViewColumn({ name: 'movie_id' })
   movieId: number;
@@ -8,42 +9,15 @@ export class MainMovieView {
   @ViewColumn({ name: 'movie_title' })
   movieTitle: string;
 
-  @ViewColumn({ name: 'eight_weeks_before_price' })
-  eightWeeksBeforePrice: number;
+  @ViewColumn({ name: 'movie_open_date' })
+  movieOpenDate: string;
 
-  @ViewColumn({ name: 'eight_weeks_after_price' })
-  eightWeeksAfterPrice: number;
-
-  @ViewColumn({ name: 'four_weeks_before_price' })
-  fourWeeksBeforePrice: number;
-
-  @ViewColumn({ name: 'four_weeks_after_price' })
-  fourWeeksAfterPrice: number;
-
-  @ViewColumn({ name: 'movie_open_date_stock_price' })
-  movieOpenDateStockPrice: number;
-
-  @ViewColumn({ name: 'movie_open_date_stock_date' })
-  movieOpenDateStockDate: Date;
-
-  @ViewColumn({ name: 'four_weeks_before_date' })
-  fourWeeksBeforeDate: Date;
-
-  @ViewColumn({ name: 'four_weeks_after_date' })
-  fourWeeksAfterDate: Date;
-
-  @ViewColumn({ name: 'eight_weeks_before_date' })
-  eightWeeksBeforeDate: Date;
-
-  @ViewColumn({ name: 'eight_weeks_after_date' })
-  eightWeeksAfterDate: Date;
-
-  @ViewColumn({ name: 'movie_poster' })
-  moviePoster: string;
+  @ViewColumn({ name: 'company_name' })
+  companyName: string;
 
   @ViewColumn({ name: 'country' })
   country: string;
 
-  @ViewColumn({ name: 'company_name' })
-  companyName: string;
+  @ViewColumn({ name: 'movie_poster' })
+  moviePoster: string;
 }

--- a/src/main/main.service.ts
+++ b/src/main/main.service.ts
@@ -30,50 +30,30 @@ export class MainService {
     try {
       const movieList = await this.mainMovieRepository.find();
 
-      /**
-       * SELECT
-            stock.stock_date,
-            stock.close_price
-        FROM
-            main_movie_view_to_be m
-        JOIN
-            company ON company.company_name = m.company_name
-        JOIN
-            stock ON stock.ticker_name = company.ticker_name
-            AND stock.stock_date BETWEEN 
-                    m.movie_open_date - INTERVAL '4 weeks' AND 
-                    m.movie_open_date + INTERVAL '4 weeks'
-        WHERE m.movie_id= :m.movie_id
-       */
-      // movieList
       const movieListWithStockData = await Promise.all(
-        movieList.map((movie) => {
+        movieList.map(async (movie) => {
           const movieId = movie.movieId;
 
           try {
-            const queryBuilder = this.mainMovieRepository
-              .createQueryBuilder('m')
-              .select(['stock.stock_date', 'stock.close_price'])
-              .innerJoin(
-                'company',
-                'company',
-                'company.ticker_name = m.ticker_name',
-              )
-              .innerJoin(
-                'stock',
-                'stock',
-                `stock.ticker_name = company.ticker_name
-            AND stock.stock_date BETWEEN m.movie_open_date - INTERVAL '4 weeks'
-            AND m.movie_open_date + INTERVAL '4 weeks'
-            `,
-              )
-              .where('m.movie_id = :movie_id', { movieId });
-
-            const stockPriceList = queryBuilder.getMany();
-
-            console.log('stockPriceList : ', stockPriceList);
-
-            // const stockPriceList = this.mainMovieRepository.query;
+            // 직접 SQL 쿼리 사용
+            const stockPriceList = await this.mainMovieRepository.query(
+              `
+              SELECT
+                stock.stock_date,
+                stock.close_price
+              FROM
+                main_movie_view_to_be m
+              JOIN
+                company ON company.company_name = m.company_name
+              JOIN
+                stock ON stock.ticker_name = company.ticker_name
+              WHERE
+                m.movie_id = $1
+                AND stock.stock_date BETWEEN m.movie_open_date - INTERVAL '4 weeks' 
+                AND m.movie_open_date + INTERVAL '4 weeks'
+              `,
+              [movieId], // 파라미터 바인딩
+            );
 
             return {
               movieId: movie.movieId,
@@ -81,28 +61,20 @@ export class MainService {
               moviePoster: movie.moviePoster.split('|'),
               country: movie.country.trim(),
               companyName: movie.companyName,
-              // stockPriceList: (await stockPriceList).map((stock) => ({
-              //   price: stock.close_price,
-              //   date: stock.stock_date,
-              // })),
-              stockPriceList: [
-                {
-                  price: 4242,
-                  date: '2024-08-21',
-                },
-              ],
+              stockPriceList: stockPriceList.map((stock) => ({
+                price: Number(stock.close_price),
+                date: getYYYYMMDDDate(stock.stock_date),
+              })),
             };
           } catch (err) {
-            console.error('Error fetching main movies:', err);
+            console.error('Error fetching stock data for movie:', err);
             throw new HttpException(
-              '대표 영화 5개를 가져오는데 실패 하였습니다.',
+              '영화 관련 주식 데이터를 가져오는데 실패했습니다.',
               HttpStatus.INTERNAL_SERVER_ERROR,
             );
           }
         }),
       );
-
-      // movieList
 
       return {
         movieList: movieListWithStockData.map((movie) => ({
@@ -112,10 +84,6 @@ export class MainService {
           countryCode: movie.country,
           companyName: movie.companyName,
           stockPriceList: movie.stockPriceList,
-          // stockPriceList: {
-          //   price: 4242,
-          //   date: '2024-08-21',
-          // },
         })),
         movieListCount: movieList.length,
       };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #101 

## 📝작업 내용

> 개봉일 기준 4주 전, 4주 후 총 8주 간의 주식 가격 제공

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/bb6cd0ea-7cc2-462b-b1fe-708a0b74d097)


## 💬리뷰 요구사항(선택)

- 8주간의 주가 데이터를 가져오기 위해 영화별로 주가데이터를 가져오는 추가 쿼리를 보내고 있습니다. 영화 리스트를 가져오는 쿼리 1개, 영화별로 주가데이터 가져오는 쿼리 5개 총 6개를 쓰고 있습니다. 성능에 이슈가 있을까요? 어떻게 생각하시나요?
